### PR TITLE
Fix a typo in /auth/google_analytics.example.js

### DIFF
--- a/auth/google_analytics.example.js
+++ b/auth/google_analytics.example.js
@@ -1,5 +1,5 @@
 /**
- * Google Analytics tracking codes. Rename this to goole_analytics.js
+ * Google Analytics tracking codes. Rename this to google_analytics.js
  */
 
 // Tracking Codes


### PR DESCRIPTION
The instructions for renaming the example Google Analytics auth file,
taken literally, wouldn't work. Most users surely pay enough attention
not to fall into this trap, but for completeness...
