### PR TITLE
preserve file name when downloading

### DIFF
--- a/controllers/images.coffee
+++ b/controllers/images.coffee
@@ -46,7 +46,7 @@ get.download = (req, res) ->
     headers:
       "Referer": req.headers.referer
 
-  res.set "Content-Disposition", "attachment"
+  res.set "Content-Disposition", "attachment; filename=#{req.params.image}"
   imageRequest.pipe res
 
 # Delete the image


### PR DESCRIPTION
instead of using "download" as a downloaded file name, use the original name.
